### PR TITLE
feat: Sanity 캐릭터 콘텐츠 연동 기반으로 홈 화면 구조 전환

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "cdn.sanity.io",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(home)/HomeClient.tsx
+++ b/src/app/(home)/HomeClient.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import gsap from "gsap";
+import ScrollTrigger from "gsap/ScrollTrigger";
+import Image from "next/image";
+import { useEffect, useMemo, useRef } from "react";
+import { Button } from "@/src/components/ui/button";
+import { urlFor } from "@/src/sanity/lib/image";
+import { SanityImageSource } from "@sanity/image-url/lib/types/types";
+
+gsap.registerPlugin(ScrollTrigger);
+
+export type Character = {
+  _id: string;
+  name: string;
+  slug: { current: string };
+  mainImage: SanityImageSource;
+  mainVideoUrl?: string;
+  backgroundImage: SanityImageSource;
+  introQuote: string;
+  description: string;
+  ctaLabel: string;
+};
+
+type HomeClientProps = {
+  characters: Character[];
+};
+
+// ─── 분리된 타입 ───────────────────────────────────────────────
+
+type SceneElements = {
+  bg: HTMLElement;
+  overlay: HTMLElement;
+  polygon: HTMLElement;
+  image: HTMLElement;
+  text: HTMLElement;
+};
+
+// ─── 분리된 함수들 ────────────────────────────────────────────
+
+/**
+ * 각 씬 요소의 초기 상태를 세팅
+ * 첫 번째 씬만 보이고, 나머지는 모두 숨긴 상태로 시작
+ */
+function initSceneElements(
+  backgrounds: HTMLElement[],
+  overlays: HTMLElement[],
+  polygons: HTMLElement[],
+  images: HTMLElement[],
+  texts: HTMLElement[],
+) {
+  gsap.set(backgrounds, { autoAlpha: 0, scale: 1.08 });
+  gsap.set(backgrounds[0], { autoAlpha: 1, scale: 1 });
+
+  gsap.set(overlays, { autoAlpha: 0 });
+  gsap.set(overlays[0], { autoAlpha: 1 });
+
+  gsap.set(polygons, {
+    scaleY: 0,
+    transformOrigin: "top center",
+    autoAlpha: 0,
+  });
+  gsap.set(polygons[0], { scaleY: 1, autoAlpha: 0.7 });
+
+  gsap.set(images, { x: 120, autoAlpha: 0 });
+  gsap.set(images[0], { x: 0, autoAlpha: 1 });
+
+  gsap.set(texts, { x: -32, autoAlpha: 0 });
+  gsap.set(texts[0], { x: 0, autoAlpha: 1 });
+}
+
+/**
+ * 씬 전환 시 나가는 씬의 트윈을 타임라인에 추가
+ */
+function addOutroTweens(
+  tl: gsap.core.Timeline,
+  step: number,
+  prev: SceneElements,
+) {
+  tl.to(prev.text, { x: 24, autoAlpha: 0, duration: 0.35 }, step - 1);
+  tl.to(prev.image, { x: -40, autoAlpha: 0, duration: 0.45 }, step - 1);
+  tl.to(
+    prev.polygon,
+    {
+      scaleY: 0,
+      autoAlpha: 0,
+      duration: 0.35,
+      ease: "power2.in",
+    },
+    step - 1,
+  );
+  tl.to(prev.overlay, { autoAlpha: 0, duration: 0.8, ease: "none" }, step - 1);
+  tl.to(
+    prev.bg,
+    { scale: 0.985, autoAlpha: 0, duration: 0.8, ease: "none" },
+    step - 1,
+  );
+}
+
+/**
+ * 씬 전환 시 들어오는 씬의 트윈을 타임라인에 추가
+ */
+function addIntroTweens(
+  tl: gsap.core.Timeline,
+  step: number,
+  next: SceneElements,
+) {
+  tl.to(next.text, { x: 0, autoAlpha: 1, duration: 0.45 }, step - 0.7);
+  tl.to(next.image, { x: 0, autoAlpha: 1, duration: 0.55 }, step - 0.72);
+  tl.to(
+    next.polygon,
+    {
+      scaleY: 1,
+      autoAlpha: 0.7,
+      duration: 0.7,
+      ease: "power3.out",
+    },
+    step - 0.82,
+  );
+  tl.to(next.overlay, { autoAlpha: 1, duration: 0.8, ease: "none" }, step - 1);
+  tl.to(
+    next.bg,
+    { scale: 1, autoAlpha: 1, duration: 0.8, ease: "none" },
+    step - 1,
+  );
+}
+
+/**
+ * ScrollTrigger가 붙은 메인 타임라인을 생성
+ */
+function createScrollTimeline(
+  trigger: HTMLElement,
+  totalSteps: number,
+): gsap.core.Timeline {
+  return gsap.timeline({
+    defaults: { ease: "power2.out" },
+    scrollTrigger: {
+      trigger,
+      start: "top",
+      end: () => `+=${window.innerHeight * Math.max(totalSteps, 1)}`,
+      pin: true,
+      scrub: 1,
+      invalidateOnRefresh: true,
+      snap:
+        totalSteps > 0
+          ? {
+              snapTo: 1 / totalSteps,
+              duration: { min: 0.2, max: 0.45 },
+              ease: "power1.inOut",
+            }
+          : undefined,
+    },
+  });
+}
+
+// ─── 상수 ────────────────────────────────────────────────────
+
+const polygonColorBySlug: Record<string, string> = {
+  nayuta: "#2c3a4f",
+  guren: "#3a090f",
+  siren: "#162a30",
+};
+
+const imageClassBySlug: Record<string, string> = {
+  nayuta: "right-0 bottom-[-15%] max-w-[1100px]",
+  guren: "right-20 bottom-[-12%] max-w-[1100px]",
+  siren: "right-25 bottom-[-15%] max-w-[1050px]",
+};
+
+// ─── 컴포넌트 ────────────────────────────────────────────────
+
+export default function HomeClient({ characters }: HomeClientProps) {
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  const items = useMemo(
+    () =>
+      characters
+        .filter((c) => c.slug?.current)
+        .map((c) => ({
+          ...c,
+          mainImageUrl: urlFor(c.mainImage).width(1200).quality(90).url(),
+          backgroundImageUrl: urlFor(c.backgroundImage)
+            .width(1920)
+            .quality(85)
+            .url(),
+          polygonColor: polygonColorBySlug[c.slug.current],
+        })),
+    [characters],
+  );
+
+  useEffect(() => {
+    if (!rootRef.current || items.length === 0) return;
+
+    const ctx = gsap.context(() => {
+      const backgrounds = gsap.utils.toArray<HTMLElement>("[data-bg]");
+      const overlays = gsap.utils.toArray<HTMLElement>("[data-overlay]");
+      const polygons = gsap.utils.toArray<HTMLElement>("[data-polygon]");
+      const images = gsap.utils.toArray<HTMLElement>("[data-image]");
+      const texts = gsap.utils.toArray<HTMLElement>("[data-text]");
+      const sections = gsap.utils.toArray<HTMLElement>("[data-scene]");
+
+      if (sections.length === 0) return;
+
+      // 초기 상태 세팅
+      initSceneElements(backgrounds, overlays, polygons, images, texts);
+
+      // 타임라인 생성
+      const totalSteps = sections.length - 1;
+      const tl = createScrollTimeline(rootRef.current!, totalSteps);
+
+      // 씬 전환 트윈 추가
+      for (let i = 1; i < sections.length; i++) {
+        const prev: SceneElements = {
+          bg: backgrounds[i - 1],
+          overlay: overlays[i - 1],
+          polygon: polygons[i - 1],
+          image: images[i - 1],
+          text: texts[i - 1],
+        };
+        const next: SceneElements = {
+          bg: backgrounds[i],
+          overlay: overlays[i],
+          polygon: polygons[i],
+          image: images[i],
+          text: texts[i],
+        };
+
+        addOutroTweens(tl, i, prev);
+        addIntroTweens(tl, i, next);
+      }
+    }, rootRef);
+
+    return () => ctx.revert();
+  }, [items]);
+
+  if (items.length === 0) {
+    return (
+      <main className="relative min-h-screen bg-[#061022] text-[#eff4ff]" />
+    );
+  }
+
+  return (
+    <main
+      ref={rootRef}
+      className="relative h-screen overflow-hidden bg-[#061022] bg-black/55"
+    >
+      {items.map((c, i) => (
+        <section
+          key={c._id}
+          data-scene
+          className="absolute inset-0 overflow-hidden "
+        >
+          <div
+            data-bg
+            className="absolute inset-0 bg-cover bg-center will-change-transform"
+            style={{ backgroundImage: `url('${c.backgroundImageUrl}')` }}
+          />
+          <div data-overlay className="absolute inset-0 bg-black/55" />
+
+          <div className="relative mx-auto h-full w-full max-w-[1520px] px-6 sm:px-10 md:px-16 lg:px-20">
+            <div
+              className="absolute inset-y-0 right-0 w-[52vw] max-w-[820px] overflow-hidden"
+              style={{
+                clipPath: "polygon(35% 0, 100% 0, 62% 100%, 0 100%)",
+              }}
+            >
+              <div
+                data-polygon
+                className="absolute inset-0 will-change-transform"
+                style={{ backgroundColor: c.polygonColor }}
+              />
+            </div>
+
+            <div
+              data-text
+              className="relative z-10 flex h-full max-w-[520px] flex-col justify-center"
+            >
+              <h1 className="text-5xl font-bold">{c.name}</h1>
+              <p className="mt-7 mb-10 whitespace-pre-line text-2xl font-medium leading-relaxed">
+                {c.introQuote}
+              </p>
+              <p className="mb-10 whitespace-pre-line text-lg leading-relaxed text-[#dbe5f7]">
+                {c.description}
+              </p>
+              <div>
+                <Button as="a" href={`/simulations/${c.slug.current}`}>
+                  {c.ctaLabel}
+                </Button>
+              </div>
+            </div>
+
+            <div
+              data-image
+              className={`absolute z-10 will-change-transform ${imageClassBySlug[c.slug.current] ?? "right-0 bottom-[-18%]"}`}
+            >
+              {c.mainVideoUrl ? (
+                <video
+                  src={c.mainVideoUrl}
+                  autoPlay
+                  loop
+                  muted
+                  playsInline
+                  preload={i === 0 ? "auto" : "metadata"}
+                  aria-label={`${c.name} 영상`}
+                  className="h-auto w-full object-contain"
+                />
+              ) : (
+                <Image
+                  src={c.mainImageUrl}
+                  alt={`${c.name} 일러스트`}
+                  width={1200}
+                  height={1200}
+                  priority={i === 0}
+                  className="h-auto w-full object-contain"
+                />
+              )}
+            </div>
+          </div>
+        </section>
+      ))}
+    </main>
+  );
+}

--- a/src/app/(home)/HomeClient.tsx
+++ b/src/app/(home)/HomeClient.tsx
@@ -198,7 +198,7 @@ export default function HomeClient({ characters }: HomeClientProps) {
             .width(1920)
             .quality(85)
             .url(),
-          polygonColor: polygonColorBySlug[c.slug.current],
+          polygonColor: polygonColorBySlug[c.slug.current] ?? "#1a1a2e",
         })),
     [characters],
   );

--- a/src/app/(home)/HomeClient.tsx
+++ b/src/app/(home)/HomeClient.tsx
@@ -49,6 +49,16 @@ function initSceneElements(
   images: HTMLElement[],
   texts: HTMLElement[],
 ) {
+  if (
+    backgrounds.length === 0 ||
+    overlays.length === 0 ||
+    polygons.length === 0 ||
+    images.length === 0 ||
+    texts.length === 0
+  ) {
+    return;
+  }
+
   gsap.set(backgrounds, { autoAlpha: 0, scale: 1.08 });
   gsap.set(backgrounds[0], { autoAlpha: 1, scale: 1 });
 
@@ -178,8 +188,13 @@ export default function HomeClient({ characters }: HomeClientProps) {
         .filter((c) => c.slug?.current)
         .map((c) => ({
           ...c,
-          mainImageUrl: urlFor(c.mainImage).width(1200).quality(90).url(),
+          mainImageUrl: urlFor(c.mainImage)
+            .fit("crop")
+            .width(1200)
+            .quality(90)
+            .url(),
           backgroundImageUrl: urlFor(c.backgroundImage)
+            .fit("crop")
             .width(1920)
             .quality(85)
             .url(),

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,151 +1,20 @@
-"use client";
+import HomeClient, { type Character } from "./HomeClient";
+import { client } from "@/src/sanity/lib/client";
 
-import Image from "next/image";
-import { useEffect } from "react";
-import gsap from "gsap";
-import ScrollTrigger from "gsap/ScrollTrigger";
-import { Button } from "@/src/components/ui/button";
+const QUERY = `*[_type == "character"] | order(displayOrder asc){
+  _id,
+  name,
+  slug,
+  mainImage,
+  "mainVideoUrl": mainVideo.asset->url,
+  backgroundImage,
+  introQuote,
+  description,
+  ctaLabel
+}`;
 
-export default function Home() {
-  useEffect(() => {
-    gsap.registerPlugin(ScrollTrigger);
+export default async function HomePage() {
+  const characters = await client.fetch<Character[]>(QUERY);
 
-    const trigger = ScrollTrigger.create({
-      trigger: "character-section",
-      start: "top top",
-      // snap: 1,
-    });
-
-    return () => trigger.kill();
-  }, []);
-
-  return (
-    <main className="relative min-h-screen overflow-x-hidden bg-[#061022] text-[#eff4ff]">
-      <section className="character-section relative mx-auto h-screen w-full items-end px-6 pb-10 sm:px-10 md:px-16 lg:px-34 lg:pb-0 bg-[url('/images/nayuta-bg.png')] bg-cover bg-center overflow-hidden">
-        <div className="absolute inset-0 bg-black/60" />
-        <div className="max-w-[1520px] relative h-full">
-          <div className="absolute inset-y-0 right-0 w-[49vw] bg-[var(--color-nayuta-secondary)]/70 [clip-path:polygon(35%_0,100%_0,62%_100%,0_100%)]" />
-
-          <div
-            data-animate="text"
-            className="h-full flex flex-col justify-center"
-          >
-            <h1 className="text-5xl font-bold tracking-tight">나유타</h1>
-            <p className="text-2xl font-medium mt-7 mb-10 text-[var(--color-nayuta-text)]">
-              &quot;대협은 폭풍의 중심에 있는 자.
-              <br /> 그러니 중심을 잃고 휩쓸려 가버리지 않게 조심하시구려.&quot;
-            </p>
-            <p className="text-lg mb-10 text-[var(--color-nayuta-text)]">
-              - 파이오니아 스쿼드의 멤버 중 하나.
-              <br />
-              페어리 테일 모델이 아니기에 동화의 이름을 가지고 있진 않다.
-              <br />
-              세계 곳곳을 돌아다니며 우주에 있는 퀸의 위치,
-              <br />
-              이동 경로, 침입 시기 등을 조사하고 다니는 중. -
-            </p>
-            {/* TODO: 상세 페이지 생성 후 onClick 또는 Link로 연결 */}
-            <Button>나유타와 시뮬레이션 시작하기</Button>
-          </div>
-
-          <div
-            data-animate="image"
-            className="z-10 lg:mt-0 absolute -bottom-60 -right-5"
-          >
-            <Image
-              src="/images/nayuta.png"
-              alt="나유타 일러스트"
-              width={1200}
-              height={1200}
-              priority
-              className="h-auto w-full object-contain"
-            />
-            <div className="pointer-events-none absolute inset-x-[16%] bottom-3 h-14 bg-[#0f2340]/55 blur-2xl" />
-          </div>
-        </div>
-      </section>
-      <section className="character-section relative mx-auto h-screen w-full items-end px-6 pb-10 sm:px-10 md:px-16 lg:px-34 lg:pb-0 bg-[url('/images/guren-bg.png')] bg-cover bg-center overflow-hidden">
-        <div className="absolute inset-0 bg-black/60" />
-        <div className="max-w-[1520px] relative h-full">
-          <div className="absolute inset-y-0 right-0 w-[49vw] bg-[var(--color-guren-secondary)]/70 [clip-path:polygon(35%_0,100%_0,62%_100%,0_100%)]" />
-
-          <div
-            data-animate="text"
-            className="h-full flex flex-col justify-center"
-          >
-            <h1 className="text-5xl font-bold tracking-tight">홍련 : 흑영</h1>
-            <p className="text-2xl font-medium mt-7 mb-10 text-[var(--color-guren-text)]">
-              &quot;싸움을 거는 거라면 언제든 환영일세.&quot;
-            </p>
-            <p className="text-lg mb-10 text-[var(--color-nayuta-text)]">
-              접근전용 스쿼드 소속.
-              <br />
-              양산형으로 제작되었지만 강도 높은 커스터마이징을 받아
-              <br />
-              신체 능력은 양산형을 아득히 뛰어넘는다.
-              <br />
-              검의 천재라 불릴 정도로 압도적인 기량을 자랑한다.
-            </p>
-            {/* TODO: 상세 페이지 생성 후 onClick 또는 Link로 연결 */}
-            <Button>홍련 : 흑영과 시뮬레이션 시작하기</Button>
-          </div>
-
-          <div
-            data-animate="image"
-            className="z-10 lg:mt-0 absolute -bottom-60 right-0"
-          >
-            <Image
-              src="/images/guren.png"
-              alt="홍련 : 흑영 일러스트"
-              width={1200}
-              height={1200}
-              className="h-auto w-full object-contain"
-            />
-            <div className="pointer-events-none absolute inset-x-[16%] bottom-3 h-14 bg-[#0f2340]/55 blur-2xl" />
-          </div>
-        </div>
-      </section>
-      <section className="character-section relative mx-auto h-screen w-full items-end px-6 pb-10 sm:px-10 md:px-16 lg:px-34 lg:pb-0 bg-[url('/images/siren-bg.png')] bg-cover bg-[position:18%_bottom] overflow-hidden">
-        <div className="absolute inset-0 bg-black/60" />
-        <div className="max-w-[1520px] relative h-full">
-          <div className="absolute inset-y-0 right-0 w-[49vw] bg-[var(--color-siren-primary)]/70 [clip-path:polygon(35%_0,100%_0,62%_100%,0_100%)]" />
-
-          <div
-            data-animate="text"
-            className="h-full flex flex-col justify-center"
-          >
-            <h1 className="text-5xl font-bold tracking-tight">리틀 머메이드</h1>
-            <p className="text-2xl font-medium mt-7 mb-10 text-[var(--color-guren-text)]">
-              &quot;아, 계속 말을 해줘야 해. 말하는 법을 까먹을지도 몰라.&quot;
-            </p>
-            <p className="text-lg mb-10 text-[var(--color-nayuta-text)]">
-              2세대 페어리 테일 모델 중 하나인 니케.
-              <br />
-              이름이 길어, 주변 사람들은 보통 [세이렌]이라 부른다.
-              <br />
-              제어가 되지 않아 평소에 말을 하진 않지만,
-              <br />
-              옹알이 같은 소리로 감정을 또렷하게 표현한다.
-            </p>
-            {/* TODO: 상세 페이지 생성 후 onClick 또는 Link로 연결 */}
-            <Button>리틀 머메이드와 시뮬레이션 시작하기</Button>
-          </div>
-
-          <div
-            data-animate="image"
-            className="z-10 lg:mt-0 absolute -bottom-70 right-0"
-          >
-            <Image
-              src="/images/siren.png"
-              alt="세이렌 일러스트"
-              width={1200}
-              height={1200}
-              className="h-auto w-full object-contain"
-            />
-            <div className="pointer-events-none absolute inset-x-[16%] bottom-3 h-14 bg-[#0f2340]/55 blur-2xl" />
-          </div>
-        </div>
-      </section>
-    </main>
-  );
+  return <HomeClient characters={characters} />;
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -48,10 +48,12 @@ export const Button = <T extends ElementType = "button">(
 
   if (Component === "button") {
     const buttonProps = restProps as ComponentPropsWithoutRef<"button">;
+    const { type, ...otherButtonProps } = buttonProps;
+
     return (
       <button
-        type={buttonProps.type ?? "button"}
-        {...buttonProps}
+        type={type ?? "button"}
+        {...otherButtonProps}
         className={mergedClassName}
       >
         {children}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,32 +1,71 @@
+import {
+  createElement,
+  type ComponentPropsWithoutRef,
+  type ElementType,
+  type ReactNode,
+} from "react";
+
 type ButtonSize = "sm" | "md";
 
-type ButtonProps = {
-  children: string;
+type ButtonOwnProps<T extends ElementType> = {
+  as?: T;
+  children: ReactNode;
   size?: ButtonSize;
+  className?: string;
 };
+
+type ButtonProps<T extends ElementType> = ButtonOwnProps<T> &
+  Omit<ComponentPropsWithoutRef<T>, keyof ButtonOwnProps<T>>;
 
 const sizeClassMap: Record<ButtonSize, string> = {
   sm: "max-w-[350px]",
   md: "max-w-[500px]",
 };
 
-export const Button = ({ children, size = "sm" }: ButtonProps) => {
-  return (
-    <button
-      type="button"
-      className={`
-        w-full
-        ${sizeClassMap[size]}
-        bg-[linear-gradient(90deg,#2C3A4F_0%,#000000_30%,#000000_65%,#2C3A4F_100%)] 
-        border border-[#656565] 
-        block
-        py-5
-        cursor-pointer 
-        text-white
-        font-semibold
-        `}
-    >
-      {children}
-    </button>
+export const Button = <T extends ElementType = "button">(
+  props: ButtonProps<T>,
+) => {
+  const { as, children, size = "sm", className, ...restProps } = props;
+
+  const Component = as ?? "button";
+
+  const baseClassName = `
+    w-full
+    ${sizeClassMap[size]}
+    bg-[linear-gradient(90deg,#2C3A4F_0%,#000000_30%,#000000_65%,#2C3A4F_100%)]
+    border border-[#656565]
+    block
+    py-5
+    cursor-pointer
+    text-white
+    font-semibold
+    text-center
+  `;
+
+  const mergedClassName = [baseClassName, className].filter(Boolean).join(" ");
+  const defaultProps =
+    Component === "button" ? { type: "button" as const } : {};
+
+  if (Component === "button") {
+    const buttonProps = restProps as ComponentPropsWithoutRef<"button">;
+    return (
+      <button
+        type={buttonProps.type ?? "button"}
+        {...buttonProps}
+        className={mergedClassName}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  return createElement(
+    Component,
+    {
+      ...defaultProps,
+      ...(restProps as object),
+      className: mergedClassName,
+    },
+    children,
   );
 };

--- a/src/sanity/schemaTypes/characterType.ts
+++ b/src/sanity/schemaTypes/characterType.ts
@@ -1,0 +1,76 @@
+import { defineField, defineType } from "sanity";
+
+export const characterType = defineType({
+  name: "character", // sanity 내부 데이터에서 사용
+  title: "Character", // studio에서 보여지는 이름
+  type: "document", // 어떤 종류의 데이터인지 (현재는 하나의 문서)
+  fields: [
+    // 데이터 속성들
+    defineField({
+      // 필드 정의 함수
+      name: "displayOrder",
+      title: "메인 노출 순서",
+      type: "number",
+      validation: (rule) => rule.required().integer().min(1),
+    }),
+    defineField({
+      name: "name",
+      title: "이름",
+      type: "string",
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "slug",
+      title: "슬러그",
+      type: "slug",
+      options: { source: "name" },
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "mainImage",
+      title: "캐릭터 이미지",
+      type: "image",
+      options: { hotspot: true }, // 크롭 포인트 지정 가능
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "mainVideo",
+      title: "캐릭터 영상 (선택)",
+      type: "file",
+      options: {
+        accept: "video/mp4,video/webm",
+      },
+      description: "등록하면 메인 이미지 대신 자동 반복 재생됩니다.",
+    }),
+    defineField({
+      name: "backgroundImage",
+      title: "배경 이미지",
+      type: "image",
+      options: { hotspot: true },
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "introQuote",
+      title: "인용문",
+      type: "text",
+      rows: 3, // text 입력창 높이
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "description",
+      title: "캐릭터 설명",
+      type: "text",
+      rows: 5,
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "ctaLabel",
+      title: "버튼 문구",
+      type: "string",
+      validation: (rule) => rule.required(),
+    }),
+  ],
+  preview: {
+    select: { title: "name", subtitle: "slug.current", media: "mainImage" },
+  },
+});

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -1,6 +1,7 @@
+import { characterType } from "./characterType";
 import { postType } from "./postType";
 
-export const schemaTypes = [postType];
+export const schemaTypes = [postType, characterType];
 
 export const schema = {
   types: schemaTypes,


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #1 
> Closes #5 

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [x] Sanity `character` 문서 스키마 추가 
(`displayOrder`, `name`, `slug`, `mainImage`, `mainVideo`, `backgroundImage`, `introQuote`, `description`, `ctaLabel`)
- [x] Sanity 스키마 인덱스에 `characterType` 등록
- [x] Next.js 이미지 로더에서 `cdn.sanity.io` 원격 이미지 허용
- [x] 홈 페이지를 하드코딩 섹션에서 데이터 패칭 기반 구조로 전환 (`page.tsx` -> `HomeClient.tsx`)
- [x] GSAP/ScrollTrigger 기반 씬 전환 애니메이션을 캐릭터 배열 렌더링 방식으로 적용
- [x] 공용 `Button` 컴포넌트에 `as` prop 기반 polymorphic 렌더링 지원 추가 (예: `as="a"`)

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- 캐릭터 콘텐츠를 코드 하드코딩이 아닌 CMS(Sanity)에서 운영 가능하도록 전환하기 위함
- 신규 캐릭터 추가/수정 시 프론트 코드 수정 없이 콘텐츠 운영 효율을 높이기 위함
- 홈 화면 연출 로직을 데이터 중심으로 바꿔 확장성과 유지보수성을 개선하기 위함
- 버튼 컴포넌트 재사용 범위를 넓혀 링크/버튼 공통 UI를 일관되게 유지하기 위함

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

- [x] 코드 기준 확인: `page.tsx`에서 Sanity 쿼리 후 `HomeClient`로 데이터 전달 구조 반영 확인
- [x] 코드 기준 확인: `Button as="a"` 사용 시 타입/렌더링 경로 추가 확인
- [x] 코드 기준 확인: `next.config.ts` 원격 이미지 도메인 설정 반영 확인

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/bf1df25a-4efa-483a-b8b9-8528d1daf40e

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 인터랙티브 캐릭터 쇼케이스 추가: 스크롤 기반 씬 전환 애니메이션, 이미지/동영상, 소개문 및 CTA 제공.
  * 서버사이드 데이터 로드로 초기 렌더링 및 데이터 페칭 개선.
  * 원격 CDN 이미지 최적화 구성 적용으로 이미지 로딩 성능 향상.

* **Chores**
  * 버튼 컴포넌트 확장(다양한 요소 렌더링 및 스타일 옵션).
  * 캐릭터 콘텐츠 유형 추가로 관리 가능한 캐릭터 항목 지원.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->